### PR TITLE
Fix keepalives

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -114,7 +114,11 @@ func process(transport *http.Transport, d *Data, req *http.Request, w http.Respo
 
 func copyHeaders(dst http.Header, src http.Header) {
 	for k := range src {
-		dst.Set(k, src.Get(k))
+		// Do not copy "Connection: close" header, as it makes keep-alives impossible.
+		// For example, Savon sends it with every request
+		if k != "Connection" {
+			dst.Set(k, src.Get(k))
+		}
 	}
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -36,7 +36,7 @@ type Times struct {
 }
 
 // maximum of idle upstream connections to keep open
-const httpMaxIdleConns = 100
+const httpMaxIdleConns = 256
 
 // NewHandler creates http.HandlerFunc that proxies requests
 // to the given URL
@@ -85,6 +85,7 @@ func newTransport(timeout time.Duration) *http.Transport {
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:          httpMaxIdleConns,
+		MaxIdleConnsPerHost:   httpMaxIdleConns,
 		IdleConnTimeout:       timeout,
 		ResponseHeaderTimeout: timeout,
 		ExpectContinueTimeout: 1 * time.Second,


### PR DESCRIPTION
Weekend fun with Cake.

В четверг вечером/ночью время выполнения запросов в Cake резко выросло до размеров, при которых начали поступать жалобы от игроков. Также некоторые казино-провайдеры (PlaynGO, Microgaming) начали бросать ошибки из-за задержек, т.к. их внутренние таймауты срабатывали раньше, чем они получали ответ от нас.

![image](https://user-images.githubusercontent.com/13393/72227662-9157d900-35f3-11ea-9deb-6e5a419e657c.png)

После нескольких день переписки с саппортом Кейка, вчера решено было ребутнуть сервер. После этого они заметили, что с нашего ip постоянно переоткрываются соединения, что приводит к повисанию старых в состоянии TIME_WAIT - соединение закрыто, но пока остаётся в ожидании возможных оставшихся пакетов. Возникла теория, что это может приводить к наблюдаемым проблемам из-за того, что слишком большое количество TIME_WAIT соединений постепенно исчерпывает сетевые ресурсы на сервере.

С нашей стороны всё подчищалось, но постоянное переоткрытие соединений подтвердилось - локальный номер порта в `netstat -nt | grep 54.93.230.66` постоянно менялся, что указывало на закрываемые и открываемые соединения. Что было странно, т.к. в `net/http` из Go по умолчанию имеется и включена поддержка keep-alive соединений - т.е. после завершения запроса соединение сразу не закрывается, а уходит в пул неактивных соединений, откуда может быть взято для повторного использование без полной переустановки TCP-канала.

Первым подозрением стало `const DefaultMaxIdleConnsPerHost = 2` в [transport.go](https://golang.org/src/net/http/transport.go) - что означало, что только два соединения к CakeServices будут поддерживаться в keepalive-пуле. Но [увеличение этого значения](https://github.com/redstarnv/proxy/pull/4/commits/e73eb862731094bef75715dc570183eb1ad1017b#diff-ddf6a9e7c9b2d4f21e3a3eabfe7c7d77R88) не дало желаемого результата.

После этого начал искать проблему в других направлениях. В итоге нашёл ответ, сдампив [передаваемым заголовки запросов](https://github.com/redstarnv/proxy/blob/master/proxy.go#L114) - с рельсового сайта (т.е. от Savon) все запросы приходили с заголовком `Connection: close`, что убивало открытое соединение и приводило к наблюдаемому результату.

[Исключение данного заголовка из копируемых](https://github.com/redstarnv/proxy/pull/4/commits/960f5bb9262effdb30a01f94c6d08a12a686d594) решило проблему - соединения перестали переоткрываться.

Также это дало значительный положительный эффект и на скорости обработки запросов в целом:

![image](https://user-images.githubusercontent.com/13393/72227960-68851300-35f6-11ea-983f-594366fd05ae.png)

Как видно, значительная часть запросов стала обрабатываться в пределах 50ms - чего раньше не было, минимальным временем на запросы у нас всегда было 100ms-150ms.